### PR TITLE
use a 'listen_at' argument (e.g. 0.0.0.0:1234) instead of only a 'por…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://chriseth.github.io/pathfinder2/edges.dat
 
 #### Using the Server
 
-`cargo run --release <port>` will start a JSON-RPC server listening on the given port.
+`cargo run --release <ip-address>:<port>` will start a JSON-RPC server listening on the given port.
 
 It implements the interface specified in https://hackmd.io/Gg04t7gjQKeDW2Q6Jchp0Q
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -3,10 +3,6 @@ use std::env;
 use pathfinder2::server;
 
 fn main() {
-    let port = if env::args().len() == 1 {
-        8080
-    } else {
-        env::args().nth(1).unwrap().as_str().parse::<u16>().unwrap()
-    };
-    server::start_server(port, 10, 4);
+    let listen_at = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    server::start_server(&listen_at, 10, 4);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ struct JsonRpcRequest {
     params: JsonValue,
 }
 
-pub fn start_server(port: u16, queue_size: usize, threads: u64) {
+pub fn start_server(listen_at: &str, queue_size: usize, threads: u64) {
     let edges: Arc<RwLock<Arc<EdgeDB>>> = Arc::new(RwLock::new(Arc::new(EdgeDB::default())));
 
     let (sender, receiver) = mpsc::sync_channel(queue_size);
@@ -33,8 +33,7 @@ pub fn start_server(port: u16, queue_size: usize, threads: u64) {
             }
         });
     }
-    let listener =
-        TcpListener::bind(format!("127.0.0.1:{port}")).expect("Could not create server.");
+    let listener = TcpListener::bind(listen_at).expect("Could not create server.");
     loop {
         match listener.accept() {
             Ok((socket, _)) => match sender.try_send(socket) {


### PR DESCRIPTION
…t' (1234). Allows to select an interface to listen on.